### PR TITLE
Network module fixed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,4 +39,5 @@ module "compute" {
   keypair_name     = openstack_compute_keypair_v2.kubernetes.name
   master_volume_ids = module.volumes.master_volume_ids
   worker_volume_ids = module.volumes.worker_volume_ids
+  control_plane_floating_ip = module.network.control_plane_floating_ip
 }

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -5,21 +5,13 @@ resource "openstack_compute_instance_v2" "master" {
   image_id          = var.image_id
   flavor_name       = var.master_flavor
   key_pair          = var.keypair_name
-  security_groups   = ["default", openstack_compute_secgroup_v2.kubernetes.name]
+  security_groups   = ["default", var.security_group_id]
 
   network {
     uuid = var.network_id
   }
 
   user_data = file("${path.module}/cloud-init.yaml")
-
-  # Assign floating IP to the first master node for external access
-  dynamic "network" {
-    for_each = count.index == 0 ? [1] : []
-    content {
-      name = "public"  # Change to match your external network name if different
-    }
-  }
 }
 
 # Create worker nodes
@@ -29,7 +21,7 @@ resource "openstack_compute_instance_v2" "worker" {
   image_id          = var.image_id
   flavor_name       = var.worker_flavor
   key_pair          = var.keypair_name
-  security_groups   = ["default", openstack_compute_secgroup_v2.kubernetes.name]
+  security_groups   = ["default", var.security_group_id]
 
   network {
     uuid = var.network_id
@@ -52,56 +44,13 @@ resource "openstack_compute_volume_attach_v2" "worker_volume_attachment" {
   volume_id   = var.worker_volume_ids[count.index]
 }
 
-# Create a separate security group for the instances to avoid circular dependencies
-resource "openstack_compute_secgroup_v2" "kubernetes" {
-  name        = "kubernetes-instances-secgroup"
-  description = "Security group for Kubernetes instances"
-
-  rule {
-    from_port   = 22
-    to_port     = 22
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 6443
-    to_port     = 6443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 1
-    to_port     = 65535
-    ip_protocol = "tcp"
-    self        = true
-  }
-
-  rule {
-    from_port   = 1
-    to_port     = 65535
-    ip_protocol = "udp"
-    self        = true
-  }
-
-  rule {
-    from_port   = -1
-    to_port     = -1
-    ip_protocol = "icmp"
-    cidr        = "0.0.0.0/0"
-  }
+# Get the first master node's port for floating IP attachment
+data "openstack_networking_port_v2" "master_port" {
+  device_id = openstack_compute_instance_v2.master[0].id
 }
 
-# Create floating IPs for master nodes
-resource "openstack_networking_floatingip_v2" "master" {
-  count = var.master_count
-  pool  = "public"  # Change this to your external network name if different
-}
-
-# Associate floating IPs with master nodes
-resource "openstack_compute_floatingip_associate_v2" "master" {
-  count       = var.master_count
-  floating_ip = openstack_networking_floatingip_v2.master[count.index].address
-  instance_id = openstack_compute_instance_v2.master[count.index].id
+# Associate floating IP with the first master node's port
+resource "openstack_networking_floatingip_associate_v2" "master_control_plane" {
+  floating_ip = var.control_plane_floating_ip
+  port_id     = data.openstack_networking_port_v2.master_port.id
 }

--- a/modules/compute/outputs.tf
+++ b/modules/compute/outputs.tf
@@ -1,6 +1,6 @@
 output "master_ips" {
   description = "IP addresses of the Kubernetes master nodes"
-  value       = openstack_networking_floatingip_v2.master[*].address
+  value       = openstack_compute_instance_v2.master[*].access_ip_v4
 }
 
 output "worker_ips" {

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -52,3 +52,8 @@ variable "worker_volume_ids" {
   description = "IDs of volumes to attach to worker nodes"
   type        = list(string)
 }
+
+variable "control_plane_floating_ip" {
+  description = "Floating IP to associate with the first master node"
+  type        = string
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -37,12 +37,21 @@ resource "openstack_networking_secgroup_v2" "kubernetes" {
   description = "Security group for Kubernetes cluster"
 }
 
+# Allow ARP requests
+resource "openstack_networking_secgroup_rule_v2" "ARP" {
+  direction         = "ingress"
+  remote_group_id   = openstack_networking_secgroup_v2.kubernetes.id
+  ethertype         = "IPv4"
+  security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+}
+
 # Allow all internal communication between nodes
 resource "openstack_networking_secgroup_rule_v2" "internal" {
   direction         = "ingress"
   ethertype         = "IPv4"
   remote_ip_prefix  = var.subnet_cidr
   security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+  description       = "Allow all internal communication between nodes"
 }
 
 # Allow SSH access
@@ -54,6 +63,7 @@ resource "openstack_networking_secgroup_rule_v2" "ssh" {
   port_range_max    = 22
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+  description       = "Allow SSH access"
 }
 
 # Allow HTTPS/Kubernetes API
@@ -65,6 +75,7 @@ resource "openstack_networking_secgroup_rule_v2" "kube_api" {
   port_range_max    = 6443
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+  description       = "Allow HTTPS/Kubernetes API"
 }
 
 # Allow ICMP
@@ -74,6 +85,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
   protocol          = "icmp"
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+  description       = "Allow ICMP"
 }
 
 # Allow NodePort services
@@ -85,4 +97,9 @@ resource "openstack_networking_secgroup_rule_v2" "nodeport" {
   port_range_max    = 32767
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.kubernetes.id
+}
+
+# Reserve a floating IP for the Kubernetes control plane (master-1)
+resource "openstack_networking_floatingip_v2" "control_plane" {
+  pool = "public"  # Change to your external network name if different
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -17,3 +17,13 @@ output "security_group_id" {
   description = "ID of the created security group"
   value       = openstack_networking_secgroup_v2.kubernetes.id
 }
+
+output "control_plane_floating_ip" {
+  description = "Floating IP reserved for the Kubernetes control plane"
+  value       = openstack_networking_floatingip_v2.control_plane.address
+}
+
+output "control_plane_floating_ip_id" {
+  description = "ID of the floating IP reserved for the Kubernetes control plane"
+  value       = openstack_networking_floatingip_v2.control_plane.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "security_group_id" {
   description = "ID of the created security group"
   value       = module.network.security_group_id
 }
+
+output "control_plane_floating_ip" {
+  description = "Floating IP assigned to the Kubernetes control plane"
+  value       = module.network.control_plane_floating_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,31 @@
-variable "openstack_auth_url" {
-  description = "The OpenStack authentication URL"
-  type        = string
-}
+# OpenStack Authentication Variables #
+## If you want to use declarative OpenStack authentication, uncomment the following variables and set the values in terraform.tfvars file ##
+# variable "openstack_auth_url" {
+#   description = "The OpenStack authentication URL"
+#   type        = string
+# }
 
-variable "openstack_user_name" {
-  description = "The OpenStack username"
-  type        = string
-}
+# variable "openstack_user_name" {
+#   description = "The OpenStack username"
+#   type        = string
+# }
 
-variable "openstack_tenant_name" {
-  description = "The OpenStack tenant/project name"
-  type        = string
-}
+# variable "openstack_tenant_name" {
+#   description = "The OpenStack tenant/project name"
+#   type        = string
+# }
 
-variable "openstack_password" {
-  description = "The OpenStack password"
-  type        = string
-  sensitive   = true
-}
+# variable "openstack_password" {
+#   description = "The OpenStack password"
+#   type        = string
+#   sensitive   = true
+# }
 
-variable "openstack_region" {
-  description = "The OpenStack region"
-  type        = string
-  default     = "RegionOne"
-}
+# variable "openstack_region" {
+#   description = "The OpenStack region"
+#   type        = string
+#   default     = "RegionOne"
+# }
 
 variable "network_name" {
   description = "Name of the network to create"


### PR DESCRIPTION
This pull request introduces significant updates to the Terraform configuration for managing an OpenStack-based Kubernetes cluster. The changes focus on improving network configuration, simplifying security group management, and introducing a floating IP for the Kubernetes control plane. Additionally, some variables have been modified to support more flexible authentication.

### Networking and Floating IP Improvements:
* Added a new variable `control_plane_floating_ip` to associate a floating IP with the first Kubernetes master node for external access (`modules/compute/variables.tf`).
* Updated `main.tf` to pass the `control_plane_floating_ip` variable to the compute module (`main.tf`).
* Replaced per-master floating IP assignments with a single floating IP for the control plane, and associated it with the first master node's port (`modules/compute/main.tf`).

### Security Group Simplification:
* Removed the custom `openstack_compute_secgroup_v2.kubernetes` resource and replaced it with a pre-existing security group passed as a variable (`modules/compute/main.tf`). [[1]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL8-L22) [[2]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL32-R24)
* Added descriptions to security group rules for better documentation (`modules/network/main.tf`). [[1]](diffhunk://#diff-7339956c0cb67e960e5971ab4ce47b37cd6de3baa53687a41720ad7a51c0d835R66) [[2]](diffhunk://#diff-7339956c0cb67e960e5971ab4ce47b37cd6de3baa53687a41720ad7a51c0d835R78) [[3]](diffhunk://#diff-7339956c0cb67e960e5971ab4ce47b37cd6de3baa53687a41720ad7a51c0d835R88)

### Modular Outputs:
* Updated `outputs.tf` to expose the `control_plane_floating_ip` and its ID for external use (`modules/network/outputs.tf`, `outputs.tf`). [[1]](diffhunk://#diff-0440e532eed380c869aa98f74d6364d8a03288f0174229cd0efdeea306a6debaR20-R29) [[2]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7R30-R34)
* Changed the `master_ips` output to use the `access_ip_v4` of master instances instead of floating IPs (`modules/compute/outputs.tf`).

### Authentication Variables:
* Commented out OpenStack authentication variables in `variables.tf` to encourage declarative configuration via `terraform.tfvars` instead of hardcoding them (`variables.tf`).

### Additional Enhancements:
* Reserved a floating IP resource for the Kubernetes control plane (`modules/network/main.tf`).
* Added a new security group rule to allow ARP requests for better network compatibility (`modules/network/main.tf`).