### PR TITLE
Network ports added externally

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,13 @@ module "network" {
   subnet_cidr      = var.subnet_cidr
   dns_nameservers  = var.dns_nameservers
   router_name      = var.router_name
+  
+  # Pass node counts to network module for port creation
+  master_count     = var.master_count
+  worker_count     = var.worker_count
+  
+  # Pass the number of floating IPs to reserve for MetalLB
+  metallb_floating_ip_count = var.metallb_floating_ip_count
 }
 
 # Volumes module
@@ -30,7 +37,7 @@ module "compute" {
 
   network_id       = module.network.network_id
   subnet_id        = module.network.subnet_id
-  security_group_id = module.network.security_group_id
+  security_group_id = module.network.secgroup_id
   image_id         = var.image_id
   master_count     = var.master_count
   worker_count     = var.worker_count
@@ -40,4 +47,8 @@ module "compute" {
   master_volume_ids = module.volumes.master_volume_ids
   worker_volume_ids = module.volumes.worker_volume_ids
   control_plane_floating_ip = module.network.control_plane_floating_ip
+  
+  # Pass the pre-created ports with allowed address pairs
+  master_port_ids  = module.network.master_port_ids
+  worker_port_ids  = module.network.worker_port_ids
 }

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -57,3 +57,13 @@ variable "control_plane_floating_ip" {
   description = "Floating IP to associate with the first master node"
   type        = string
 }
+
+variable "master_port_ids" {
+  description = "IDs of pre-created ports for master nodes with allowed address pairs"
+  type        = list(string)
+}
+
+variable "worker_port_ids" {
+  description = "IDs of pre-created ports for worker nodes with allowed address pairs"
+  type        = list(string)
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -13,17 +13,32 @@ output "router_id" {
   value       = openstack_networking_router_v2.kubernetes.id
 }
 
-output "security_group_id" {
+output "secgroup_id" {
   description = "ID of the created security group"
   value       = openstack_networking_secgroup_v2.kubernetes.id
 }
 
 output "control_plane_floating_ip" {
-  description = "Floating IP reserved for the Kubernetes control plane"
+  description = "Floating IP allocated for the Kubernetes control plane"
   value       = openstack_networking_floatingip_v2.control_plane.address
 }
 
-output "control_plane_floating_ip_id" {
-  description = "ID of the floating IP reserved for the Kubernetes control plane"
-  value       = openstack_networking_floatingip_v2.control_plane.id
+output "master_port_ids" {
+  description = "IDs of the created master node ports"
+  value       = openstack_networking_port_v2.master_port[*].id
+}
+
+output "worker_port_ids" {
+  description = "IDs of the created worker node ports"
+  value       = openstack_networking_port_v2.worker_port[*].id
+}
+
+output "metallb_floating_ips" {
+  description = "Floating IPs reserved for MetalLB"
+  value       = openstack_networking_floatingip_v2.metallb_floating_ips[*].address
+}
+
+output "metallb_floating_ip_ids" {
+  description = "IDs of the floating IPs reserved for MetalLB"
+  value       = openstack_networking_floatingip_v2.metallb_floating_ips[*].id
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -17,3 +17,19 @@ variable "router_name" {
   description = "Name of the router to create"
   type        = string
 }
+
+variable "metallb_floating_ip_count" {
+  description = "Number of floating IPs to reserve for MetalLB"
+  type        = number
+  default     = 1
+}
+
+variable "master_count" {
+  description = "Number of Kubernetes master nodes"
+  type        = number
+}
+
+variable "worker_count" {
+  description = "Number of Kubernetes worker nodes"
+  type        = number
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,12 +23,17 @@ output "router_id" {
   value       = module.network.router_id
 }
 
-output "security_group_id" {
+output "secgroup_id" {
   description = "ID of the created security group"
-  value       = module.network.security_group_id
+  value       = module.network.secgroup_id
 }
 
 output "control_plane_floating_ip" {
   description = "Floating IP assigned to the Kubernetes control plane"
   value       = module.network.control_plane_floating_ip
+}
+
+output "metallb_floating_ips" {
+  description = "Floating IPs reserved for MetalLB"
+  value       = module.network.metallb_floating_ips
 }

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,9 @@ variable "worker_volume_size" {
   type        = number
   default     = 150
 }
+
+variable "metallb_floating_ip_count" {
+  description = "Number of floating IPs to reserve for MetalLB"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the Terraform configuration for a Kubernetes cluster on OpenStack. The changes focus on improving networking flexibility, enabling MetalLB integration, and simplifying resource assignments by leveraging pre-created ports with allowed address pairs. Below is a summary of the most important changes grouped by theme.

### Networking Enhancements
* Added support for pre-creating ports with allowed address pairs for Kubernetes master and worker nodes, enabling more granular control over security groups and IP assignments. (`modules/network/main.tf`, `modules/compute/main.tf`) [[1]](diffhunk://#diff-7339956c0cb67e960e5971ab4ce47b37cd6de3baa53687a41720ad7a51c0d835R106-R154) [[2]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL8-R12) [[3]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL24-R29)
* Reserved floating IPs for MetalLB by introducing a new resource to allocate a configurable number of IPs from the external network. (`modules/network/main.tf`)

### Variable and Output Updates
* Introduced new variables (`master_port_ids`, `worker_port_ids`, `metallb_floating_ip_count`, `master_count`, `worker_count`) to configure the number of nodes, pre-created ports, and MetalLB floating IPs. (`modules/network/variables.tf`, `modules/compute/variables.tf`) [[1]](diffhunk://#diff-aaf0e04f619101a8ec284e579ac8125869078eaf0a8077b83119ec68719f59b4R20-R35) [[2]](diffhunk://#diff-b9ad47f10fa422e97035391509e8d9d249fcf55138f5691753862fd6ef45bf3aR60-R69) [[3]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR105-R110)
* Updated outputs to expose IDs of created ports and reserved MetalLB floating IPs for better integration with other modules. (`modules/network/outputs.tf`, `outputs.tf`) [[1]](diffhunk://#diff-0440e532eed380c869aa98f74d6364d8a03288f0174229cd0efdeea306a6debaL16-R43) [[2]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7L26-R39)

### Security Group and Resource Simplification
* Replaced direct security group assignments with pre-created ports that already include security group configurations, simplifying instance definitions. (`modules/compute/main.tf`) [[1]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL8-R12) [[2]](diffhunk://#diff-aad59185adcaa9850956ba0e136130b5cd5072662b23966ff061ea31cbbec07aL24-R29)
* Renamed `security_group_id` to `secgroup_id` in outputs for consistency. (`modules/network/outputs.tf`, `outputs.tf`) [[1]](diffhunk://#diff-0440e532eed380c869aa98f74d6364d8a03288f0174229cd0efdeea306a6debaL16-R43) [[2]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7L26-R39)

### Module Integration
* Updated the `network` and `compute` modules to pass new variables (`master_port_ids`, `worker_port_ids`, `metallb_floating_ip_count`) and integrate pre-created ports for master and worker nodes. (`main.tf`) [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR15-R21) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR50-R53)

These changes collectively enhance the flexibility, scalability, and maintainability of the Terraform configuration for Kubernetes on OpenStack.