### PR TITLE
Kernel module conf updated & cloud-init updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This Terraform project creates a Kubernetes cluster on OpenStack with the follow
 - Network infrastructure (VPC, subnet, router, security groups)
 - Persistent volumes for Kubernetes nodes
 - 3 master and 3 worker nodes pre-configured with Kubernetes dependencies
+- MetalLB integration with reserved floating IPs and allowed address pairs on all nodes
+- Pre-configured ports for all nodes with security groups
 
 ## Directory Structure
 
@@ -16,7 +18,7 @@ This Terraform project creates a Kubernetes cluster on OpenStack with the follow
 ├── versions.tf          # Terraform and provider versions
 ├── files/               # Additional files (SSH keys, etc.)
 ├── modules/
-│   ├── network/         # Network module (VPC, subnet, router, security groups)
+│   ├── network/         # Network module (VPC, subnet, router, security groups, ports, floating IPs)
 │   ├── compute/         # Compute module (instances and server configurations)
 │   └── volumes/         # Volumes module (persistent volumes for instances)
 ```
@@ -40,6 +42,9 @@ openstack_region      = "your-region"
 
 image_id              = "your-image-id"
 ssh_public_key        = "ssh-rsa AAAA..."
+
+# Optional: Configure MetalLB floating IP count
+metallb_floating_ip_count = 3  # Number of floating IPs to reserve for MetalLB
 ```
 
 You can update other variables as needed in this file.
@@ -64,7 +69,40 @@ terraform plan
 terraform apply
 ```
 
-4. After successful deployment, you'll get the IP addresses of the master and worker nodes.
+4. After successful deployment, you'll get the IP addresses of the master and worker nodes, as well as the floating IPs reserved for MetalLB.
+
+## MetalLB Configuration
+
+This deployment automatically reserves floating IPs for MetalLB and configures all nodes with allowed address pairs to support these IPs. After deploying your Kubernetes cluster, you can configure MetalLB to use these floating IPs:
+
+1. Install MetalLB in your Kubernetes cluster
+2. Configure MetalLB to use the reserved floating IPs as an address pool
+3. Create services of type LoadBalancer that will automatically use these IPs
+
+The reserved floating IP addresses can be found in the Terraform outputs:
+
+```
+terraform output metallb_floating_ips
+```
+
+### Sample MetalLB Configuration
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - <floating-ip-1>/32
+      - <floating-ip-2>/32
+      - <floating-ip-3>/32
+```
 
 ## Using the tf8 Utility Script
 
@@ -88,6 +126,7 @@ Example:
 chmod +x tf8  # Make the script executable first
 ./tf8 deploy  # Deploy the complete infrastructure
 ```
+
 ## Cleaning Up
 
 To destroy all resources:
@@ -99,3 +138,14 @@ terraform destroy
 ## Customization
 
 You can customize the deployment by modifying the variables in `variables.tf` or by providing different values in your `terraform.tfvars` file.
+
+Key variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| master_count | Number of Kubernetes master nodes | 3 |
+| worker_count | Number of Kubernetes worker nodes | 3 |
+| metallb_floating_ip_count | Number of floating IPs to reserve for MetalLB | 1 |
+| master_flavor | Flavor for master nodes | m1.large |
+| worker_flavor | Flavor for worker nodes | m1.large |
+| subnet_cidr | CIDR for the subnet | 10.0.0.0/24 |

--- a/modules/compute/cloud-init.yaml
+++ b/modules/compute/cloud-init.yaml
@@ -6,7 +6,7 @@ packages:
   - apt-transport-https
   - ca-certificates
   - curl
-  - gnupg
+  - gnupg2
   - lsb-release
   - software-properties-common
   - python3
@@ -20,6 +20,12 @@ write_files:
       net.bridge.bridge-nf-call-iptables = 1
       net.ipv4.ip_forward = 1
     permissions: '0644'
+    
+  - path: /etc/modules-load.d/containerd.conf
+    content: |
+      overlay
+      br_netfilter
+    permissions: '0644'
 
 runcmd:
   # Load required kernel modules
@@ -28,7 +34,7 @@ runcmd:
   
   # Apply sysctl settings
   - sysctl --system  
-  
+
   # Disable swap
   - swapoff -a
   - sed -i '/swap/d' /etc/fstab


### PR DESCRIPTION
This pull request introduces enhancements to the Kubernetes cluster deployment on OpenStack, focusing on MetalLB integration, documentation updates, and cloud-init improvements. Key changes include adding support for MetalLB with floating IPs, updating the documentation to reflect these changes, and improving cloud-init configurations for container runtime support.

### MetalLB Integration and Documentation Updates:
* Added MetalLB integration with reserved floating IPs and allowed address pairs for all nodes, along with pre-configured ports and security groups (`README.md`).
* Updated the `network` module description to include ports and floating IPs (`README.md`).
* Introduced a new variable, `metallb_floating_ip_count`, to configure the number of floating IPs reserved for MetalLB (`README.md`).
* Added a detailed section on MetalLB configuration, including installation steps, address pool setup, and a sample configuration (`README.md`).
* Documented key variables, including `metallb_floating_ip_count`, in a new customization table (`README.md`).

### Cloud-Init Improvements:
* Replaced `gnupg` with `gnupg2` in the `packages` list to ensure compatibility with modern systems (`modules/compute/cloud-init.yaml`).
* Added a configuration file to load required kernel modules (`overlay` and `br_netfilter`) for container runtime support (`modules/compute/cloud-init.yaml`).